### PR TITLE
new rule, from val on discord

### DIFF
--- a/staffrules.html
+++ b/staffrules.html
@@ -29,6 +29,7 @@
             <li>Members who recently got promoted, must wait 14 days before another promotion</li>
             <li>You must provide a valid reason in any warns and or bans</li>
             <li>You can't warn someone for something that happened more than 24 hours ago</li>
+            <li>Staff must send username, id, reason and proof in #ban-log when banning someone.</li>
         </ol>
         
         <hr>


### PR DESCRIPTION
"""
Mods+ now have to send username + id + reason + proof (if it was an insta ban thing like gore, spam etc)
In #ban-log 
This is a staff rule
"""